### PR TITLE
enabling separable compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(poggers VERSION 0.1.0 LANGUAGES CXX CUDA)
 
-
+set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 
 ###################################################################################################
 # - build type ------------------------------------------------------------------------------------


### PR DESCRIPTION
separable compilation was needed for building the mhm specific tests on Perlmutter.